### PR TITLE
Automatic Releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,10 @@ jobs:
   build:
     name: Build Release Binaries
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       matrix:
-        target:
-          [aarch64-apple-darwin, x86_64-apple-darwin, x86_64-unknown-linux-gnu]
+        target: [aarch64-apple-darwin, x86_64-apple-darwin]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,45 @@
+name: New Releases
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    name: Build Release Binaries
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          [aarch64-apple-darwin, x86_64-apple-darwin, x86_64-unknown-linux-gnu]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: ${{ matrix.target }}
+
+      - name: Build target
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target ${{ matrix.target }}
+
+      - name: Package
+        shell: bash
+        run: |
+          cd target/${{ matrix.target }}/release          
+          tar czvf ldap-${{ matrix.target }}.tar.gz ldap
+          cd -
+
+      - name: Publish
+        uses: softprops/action-gh-release@v1
+        with:
+          files: target/${{ matrix.target }}/release/ldap-${{ matrix.target }}.tar.gz


### PR DESCRIPTION
Adding GitHub Actions workflow to generate binary releases for any tagged commit. Right now, I'm just generating macOS binaries as that's what my team uses.